### PR TITLE
update ItemTableData.json

### DIFF
--- a/schemas/headers/ItemTableData.json
+++ b/schemas/headers/ItemTableData.json
@@ -8,7 +8,10 @@
 			"text2": "toffset",
 			"category": "ubyte",
 			"subcategory": "ubyte",
-			"icons": "data10",
+			"item_icon": "ushort",
+			"effect_icon": "ushort",
+                        "element": "ushort",
+                        "int1": "uint",
 			"float1": "float",
 			"float2": "float",
 			"effects" : {
@@ -44,7 +47,10 @@
 			"animation": "toffset",
 			"name": "toffset",
 			"description": "toffset",
-			"data" : "data16"
+			"int2": "uint", 
+                        "int3": "uint",
+			"arts_id": "uint",
+			"int4": "uint"
 		}
 	},
 	"FALCOM_SWITCH": {


### PR DESCRIPTION
changes data10 and data16  to separate values and adds names for the values of the item icon, effect icon, the element value for Quartz and Arts plugins and the ID for arts unlocked when slotting an arts plugin. I've had this sitting in my repo for a while now and won't really have any time until Ys X to work more on this so might as well push the changes than let it sit.