### PR TITLE
Fix roundtripping error in Kai no Kiseki t_help.tbl

### DIFF
--- a/schemas/headers/HelpTableData.json
+++ b/schemas/headers/HelpTableData.json
@@ -22,7 +22,7 @@
 			"file_name2": "toffset",
 			"tab_name": "toffset",
 			"empty_text_offset": "toffset",
-			"long1": "long",
+			"text": "toffset",
 			"long2": "long"
 		}
 	}


### PR DESCRIPTION
the current schema mislabels a text offset as a long, which breaks the file when recompiling. 