### PR TITLE
Update schema for t_itemhelp

### DIFF
--- a/schemas/headers/AttrTypeHelpData.json
+++ b/schemas/headers/AttrTypeHelpData.json
@@ -3,8 +3,8 @@
 		"game": "Kai",
 		"schema": {
 			"id": "long",
-			"text": "toffset",
-			"long1": "long"
+			"element_name": "toffset",
+			"long": "long"
 		}
 	}
 }

--- a/schemas/headers/ItemKindHelpData.json
+++ b/schemas/headers/ItemKindHelpData.json
@@ -2,7 +2,10 @@
 	"FALCOM_PS5": {
 		"game": "Kai",
 		"schema": {
-			"id": "long",
+			"category_id": "ushort",
+			"subcategory_id": "ushort",
+			"short1": "ushort",
+			"short2": "ushort",
 			"text1": "toffset",
 			"long": "long",
 			"text2": "toffset"

--- a/schemas/headers/SkillConnectListData.json
+++ b/schemas/headers/SkillConnectListData.json
@@ -2,9 +2,9 @@
 	"FALCOM_PS5": {
 		"game": "Kai",
 		"schema": {
-			"id": "long",
-			"long1": "long",
-			"long2": "long"
+			"id": "ulong",
+			"array": "u16array",
+			"int": "int"
 		}
 	}
 }

--- a/schemas/headers/SkillEffectHelpData.json
+++ b/schemas/headers/SkillEffectHelpData.json
@@ -2,17 +2,18 @@
 	"FALCOM_PS5": {
 		"game": "Kai",
 		"schema": {
-			"id": "long",
+			"effect_id": "ulong",
 			"text1": "toffset",
+			"array": "u32array",
+			"int1": "int",
 			"text2": "toffset",
-			"long1": "long",
 			"text3": "toffset",
 			"text4": "toffset",
 			"text5": "toffset",
+			"int2": "int",
+			"int3": "int",
 			"text6": "toffset",
-			"long2": "long",
-			"text8": "toffset",
-			"text9": "toffset"
+			"text7": "toffset"
 		}
 	}
 }

--- a/schemas/headers/SkillEffectTypeHelpData.json
+++ b/schemas/headers/SkillEffectTypeHelpData.json
@@ -3,8 +3,8 @@
 		"game": "Kai",
 		"schema": {
 			"id": "long",
-			"text": "toffset",
-			"long1": "long"
+			"skill_type_name": "toffset",
+			"text": "toffset"
 		}
 	}
 }

--- a/schemas/headers/SkillLevelHelpData.json
+++ b/schemas/headers/SkillLevelHelpData.json
@@ -3,8 +3,8 @@
 		"game": "Kai",
 		"schema": {
 			"id": "long",
-			"text": "toffset",
-			"long1": "long"
+			"text1": "toffset",
+			"text2": "toffset"
 		}
 	}
 }

--- a/schemas/headers/SkillRangeData.json
+++ b/schemas/headers/SkillRangeData.json
@@ -1,0 +1,12 @@
+{
+	"FALCOM_PS4": {
+		"game": "Kai",
+		"schema": {
+            "int": "uint",
+            "float1": "float",
+            "float2": "float",
+            "float3": "float",
+            "float4": "float"
+        }
+    }
+}

--- a/schemas/headers/SkillRangeData.json
+++ b/schemas/headers/SkillRangeData.json
@@ -2,11 +2,11 @@
 	"FALCOM_PS4": {
 		"game": "Kai",
 		"schema": {
-            "int": "uint",
-            "float1": "float",
-            "float2": "float",
-            "float3": "float",
-            "float4": "float"
+		       "int": "uint",
+		       "float1": "float",
+		       "float2": "float",
+		       "float3": "float",
+		       "float4": "float"
         }
     }
 }

--- a/schemas/headers/SkillRangeHelpData.json
+++ b/schemas/headers/SkillRangeHelpData.json
@@ -4,9 +4,9 @@
 		"schema": {
 			"id": "long",
 			"text1": "toffset",
+			"icon": "long",
 			"text2": "toffset",
-			"text3": "toffset",
-			"text4": "toffset"
+			"text3": "toffset"
 		}
 	}
 }

--- a/schemas/headers/SkillTextArrayData.json
+++ b/schemas/headers/SkillTextArrayData.json
@@ -3,8 +3,8 @@
 		"game": "Kai",
 		"schema": {
 			"id": "long",
-			"text": "toffset",
-			"long1": "long"
+			"text1": "toffset",
+			"text2": "toffset"
 		}
 	}
 }

--- a/schemas/headers/SkillTypeHelpData.json
+++ b/schemas/headers/SkillTypeHelpData.json
@@ -3,8 +3,8 @@
 		"game": "Kai",
 		"schema": {
 			"id": "long",
-			"text": "toffset",
-			"long1": "long"
+			"text1": "toffset",
+			"text2": "toffset"
 		}
 	}
 }

--- a/schemas/t_itemhelp.json
+++ b/schemas/t_itemhelp.json
@@ -12,6 +12,7 @@
 		"ItemKindHelpData",
 		"SkillEffectHelpData",
 		"ConditionHelpData",
-		"SkillRangeHelpData"
+		"SkillRangeHelpData",
+		"SkillRangeData"
 	]
 }


### PR DESCRIPTION
Fixes issues with text offsets set as long which cause the outputted tables to break, changes a few other value types to be correct and adds names to certain values.