### PR TITLE
Update NameTableData.json

### DIFF
--- a/schemas/headers/NameTableData.json
+++ b/schemas/headers/NameTableData.json
@@ -4,15 +4,15 @@
 		"schema": {
 			"character_id": "ulong",
 			"name": "toffset",
-			"texture": "toffset",
-			"face": "toffset",
 			"model": "toffset",
+			"face": "toffset",
+			"script": "toffset",
 			"long1": "ulong",
 			"text1": "toffset",
 			"text2": "toffset",
 			"long2": "ulong",
 			"text3": "toffset",
-			"text4": "toffset"
+			"full_name": "toffset"
 		}
 	},
 	"CLE_PC" :{
@@ -20,17 +20,17 @@
 		"schema": {
 			"character_id": "ulong",
 			"name": "toffset",
-			"texture": "toffset",
-			"face": "toffset",
 			"model": "toffset",
+			"face": "toffset",
+			"script": "toffset",
 			"long1": "ulong",
 			"text1": "toffset",
 			"long2": "long",
 			"text2": "toffset",
 			"long3": "ulong",
 			"text3": "toffset",
-			"text4": "toffset",
-			"text5": "toffset"
+			"full_name": "toffset",
+			"full_name_en": "toffset"
 		}
 	}
 }


### PR DESCRIPTION
Kuro 1
- Fixes some mislabeled things such as model name field being incorrectly named as texture.
- Renames last text offset to full_name as it's always used for character full names 

Kuro 2 and Kai
- Fixes some mislabeled things such as model name field being incorrectly named as texture.
- Renames last two text offsets to full_name and full_name_en as it functions the same as Kuro 1, except there is a field for Japanese, Korean and Chinese names and a second one for the same in English.