### PR TITLE
Create t_place_0.json

### DIFF
--- a/schemas/t_place_0.json
+++ b/schemas/t_place_0.json
@@ -1,0 +1,5 @@
+{
+    "headers": [
+        "PlaceTableData"
+    ]
+}


### PR DESCRIPTION
In Trails through Daybreak 2 and Kai no Kiseki there is a t_place_0.tbl file which uses the exact same schema as the normal t_place.tbl. I don't think there's a way to make it know to use the same schema without renaming the file, so I have duplicated the current t_place.json as t_place_0.json to point it to the schema for the header. 